### PR TITLE
Update to Ubuntu 12.04.5 x86_64

### DIFF
--- a/Ubuntu-12.04-x86_64/scripts/vagrant.sh
+++ b/Ubuntu-12.04-x86_64/scripts/vagrant.sh
@@ -15,6 +15,8 @@ wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/key
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
+rm -rf /var/lib/apt/lists/*
 # Install NFS for Vagrant
 apt-get update
 apt-get install -y nfs-common
+sync

--- a/Ubuntu-12.04-x86_64/template.json
+++ b/Ubuntu-12.04-x86_64/template.json
@@ -2,8 +2,8 @@
     "builders": [
         {
             "type": "virtualbox-iso",
-            "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.4-server-amd64.iso",
-            "iso_checksum": "3aeb42816253355394897ae80d99a9ba56217c0e98e05294b51f0f5b13bceb54",
+            "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
+            "iso_checksum": "af224223de99e2a730b67d7785b657f549be0d63221188e105445f75fb8305c9",
             "iso_checksum_type": "sha256",
             "boot_wait": "5s",
             "boot_command": [


### PR DESCRIPTION
久々にUbuntu 12.04 LTSの環境が欲しくなったので、Ubuntu 12.04 LTS のpacker buildをしたところ、
12.04.4 LTSのisoが指定されているURLになくなってしまっていてビルド出来なくなっていました。
と言うわけで12.04.5 LTSに更新してみました。

また、そのままだと [aptのhashsum mismatch エラー|launchpad](https://bugs.launchpad.net/ubuntu/+source/debian-installer/+bug/1430648) を踏んでしまうのでこのworkaroundも入っています。
